### PR TITLE
Added missing semicolons.

### DIFF
--- a/config/east/east_heavyvehicles.hpp
+++ b/config/east/east_heavyvehicles.hpp
@@ -16,7 +16,7 @@ class HeavyVehicles {
         };
         rearm = 500;
         requirements[] = {};
-        spawn = "I_APC_Wheeled_03_cannon_F"
+        spawn = "I_APC_Wheeled_03_cannon_F";
         class Gunner: WLTurretDefaults {
             addMagazines[] = {
                 "5Rnd_GAT_missiles",

--- a/config/west/west_heavyvehicles.hpp
+++ b/config/west/west_heavyvehicles.hpp
@@ -8,9 +8,9 @@ class HeavyVehicles {
         };
         rearm = 500;
         name = "LAV-III Stryker ICV";
-        description = "The Stryker is a family of eight-wheeled armored fighting vehicles derived from the Canadian LAV III."
+        description = "The Stryker is a family of eight-wheeled armored fighting vehicles derived from the Canadian LAV III.";
         requirements[] = {};
-        spawn = "I_APC_Wheeled_03_cannon_F"
+        spawn = "I_APC_Wheeled_03_cannon_F";
         variant = 1;
         textures[] = {
         "A3\Armor_F_Enoch\apc_tracked_03\data\apc_tracked_03_ext_eaf_co.paa",


### PR DESCRIPTION
Added missing semicolons that caused error messages in server logs:
```
14:29:47 File mpmissions\__cur_mp.Malden\config\west\west_heavyvehicles.hpp, line 11: '/CfgWLRequisitionPresets/A3ReduxAll/WEST/HeavyVehicles/B_APC_Wheeled_03_rcws_F.description': Missing ';' at the end of line   
14:29:47 File mpmissions\__cur_mp.Malden\config\west\west_heavyvehicles.hpp, line 13: '/CfgWLRequisitionPresets/A3ReduxAll/WEST/HeavyVehicles/B_APC_Wheeled_03_rcws_F.spawn': Missing ';' at the end of line         
14:29:47 File mpmissions\__cur_mp.Malden\config\east\east_heavyvehicles.hpp, line 19: '/CfgWLRequisitionPresets/A3ReduxAll/EAST/HeavyVehicles/O_APC_Wheeled_03_cannon_F.spawn': Missing ';' at the end of line
```